### PR TITLE
fix: インストールスクリプトに冪等性を追加

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -8,5 +8,16 @@ if [ "$(uname -m)" = "arm64" ] ; then
 fi
 
 # Homebrewのインストール https://brew.sh/ja/
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-eval "$(/opt/homebrew/bin/brew shellenv)"
+if ! command -v brew &> /dev/null; then
+  echo "📦 Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+else
+  echo "✅ Homebrew is already installed"
+fi
+
+# Homebrewのパスを通す
+if [ -f "/opt/homebrew/bin/brew" ]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -f "/usr/local/bin/brew" ]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi

--- a/other.sh
+++ b/other.sh
@@ -5,13 +5,23 @@ set -e
 # zplugのインストール（Homebrew経由だと変になったことがあるため公式手順通りにcurlでインストール）
 # https://github.com/zplug/zplug
 # =============================================================================
-curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh
+if [ ! -d "$HOME/.zplug" ]; then
+  echo "📦 Installing zplug..."
+  curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh
+else
+  echo "✅ zplug is already installed"
+fi
 
 # =============================================================================
 # Python実行環境の構築
 # =============================================================================
 # asdfで最新のPythonをインストール＆グローバルなバージョンに設定
-asdf plugin add python
+if ! asdf plugin list | grep -q "^python$"; then
+  echo "📦 Adding asdf python plugin..."
+  asdf plugin add python
+else
+  echo "✅ asdf python plugin is already added"
+fi
 asdf install python latest
 asdf set --home python "$(asdf list python | sed 's/  //')"
 
@@ -19,7 +29,12 @@ asdf set --home python "$(asdf list python | sed 's/  //')"
 # Node.js実行環境の構築
 # =============================================================================
 # asdfで最新のNode.jsをインストール＆グローバルなバージョンに設定
-asdf plugin add nodejs
+if ! asdf plugin list | grep -q "^nodejs$"; then
+  echo "📦 Adding asdf nodejs plugin..."
+  asdf plugin add nodejs
+else
+  echo "✅ asdf nodejs plugin is already added"
+fi
 asdf install nodejs latest
 asdf set --home nodejs "$(asdf list nodejs | sed 's/  //')"
 


### PR DESCRIPTION
複数回実行してもエラーにならないよう、既存状態をチェックしてから
インストール処理を実行するように修正。

## 変更内容
- init.sh: Homebrewが既にインストールされているかチェック
- other.sh: zplugとasdfプラグインが既に存在するかチェック

これにより、セットアップスクリプトの再実行やエラー時の
リトライが安全に行えるようになる。