### PR TITLE
fix: github.shに環境変数のバリデーション追加

### DIFF
--- a/github.sh
+++ b/github.sh
@@ -1,6 +1,22 @@
 #!/usr/local/bin/zsh
 set -e
 
+# 環境変数のバリデーション
+if [ -z "$GIT_USER_EMAIL" ]; then
+  echo "❌ Error: GIT_USER_EMAIL environment variable is not set"
+  echo "Please set it with: export GIT_USER_EMAIL=\"your-email@example.com\""
+  exit 1
+fi
+
+# メールアドレス形式の簡易的なバリデーション
+if ! echo "$GIT_USER_EMAIL" | grep -qE '^[^@]+@[^@]+\.[^@]+$'; then
+  echo "❌ Error: GIT_USER_EMAIL does not appear to be a valid email address"
+  echo "Current value: $GIT_USER_EMAIL"
+  exit 1
+fi
+
+echo "✅ Using email: $GIT_USER_EMAIL"
+
 # SSH鍵の生成
 SSH_CFGDIR="$HOME/.ssh"
 if [ ! -d $SSH_CFGDIR ]; then


### PR DESCRIPTION
GIT_USER_EMAIL環境変数が未設定または不正な形式の場合に
適切なエラーメッセージを表示して終了するように修正。

## 変更内容
- GIT_USER_EMAIL環境変数の存在チェック
- メールアドレス形式の簡易的なバリデーション
- わかりやすいエラーメッセージの追加

これにより、環境変数の設定忘れによる不正なSSH鍵の生成を防ぐ。