### PR TITLE
fix: 変数に適切な引用符を追加

### DIFF
--- a/github.sh
+++ b/github.sh
@@ -3,10 +3,10 @@ set -e
 
 # SSH鍵の生成
 SSH_CFGDIR="$HOME/.ssh"
-if [ ! -d $SSH_CFGDIR ]; then
-  mkdir -p $SSH_CFGDIR
+if [ ! -d "$SSH_CFGDIR" ]; then
+  mkdir -p "$SSH_CFGDIR"
 fi
-ssh-keygen -t ed25519 -C $GIT_USER_EMAIL
+ssh-keygen -t ed25519 -C "$GIT_USER_EMAIL"
 eval "$(ssh-agent -s)"
 
 # 以降は対話形式でSSH鍵ファイルの登録まで行う

--- a/link.sh
+++ b/link.sh
@@ -15,12 +15,12 @@ backup_and_link() {
     # バックアップ名には本日の日付を含めて作成する
     today=$(date '+%Y%m%d')
     backup="${dst_path}_${today}"
-    mv $dst_path $backup
+    mv "$dst_path" "$backup"
     echo "🚚 $name was backed up to $backup"
   fi
 
   # シンボリックリンクを作成する
-  ln -s $src_path $dst_path
+  ln -s "$src_path" "$dst_path"
   echo "🎉 Created symbolic link to $name"
 }
 
@@ -32,17 +32,17 @@ FILES=(.zshrc)
 for dotfile in "${FILES[@]}"; do
   SRC_PATH="$HERE/$dotfile"
   DST_PATH="$HOME/$dotfile"
-  backup_and_link $SRC_PATH $DST_PATH $dotfile
+  backup_and_link "$SRC_PATH" "$DST_PATH" "$dotfile"
 done
 
 # ~/.config 直下に置く設定ファイル・ディレクトリ群
 CFGDIR="$HOME/.config"
-if [ ! -d $CFGDIR ]; then
-  mkdir -p $CFGDIR
+if [ ! -d "$CFGDIR" ]; then
+  mkdir -p "$CFGDIR"
 fi
 CONFIGS=(bat git karabiner)
 for cfg in "${CONFIGS[@]}"; do
   SRC_PATH="$HERE/$cfg"
   DST_PATH="$CFGDIR/$cfg"
-  backup_and_link $SRC_PATH $DST_PATH $cfg
+  backup_and_link "$SRC_PATH" "$DST_PATH" "$cfg"
 done


### PR DESCRIPTION
ファイル名やパスにスペースが含まれる場合のエラーを防ぐため、
すべての変数参照に適切な引用符を追加。

## 変更内容
- link.sh: mv, ln, 関数呼び出しの引数に引用符を追加
- github.sh: ディレクトリチェックとコマンド引数に引用符を追加

これにより、スペースを含むパスでもスクリプトが正常に動作する。