### PR TITLE
feat: pre-commit設定を最新化＆有効なhookを追加

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,28 @@
 repos:
+  # 基本的なフック
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-added-large-files
+        args: ['--maxkb=1000']
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: mixed-line-ending
 
-  # 使い方よくわからない・・・
-  # https://github.com/shellcheck-py/shellcheck-py
-  # - repo: https://github.com/shellcheck-py/shellcheck-py
-  #   rev: v0.10.0.1
-  #   hooks:
-  #     - id: shellcheck
+  # シェルスクリプトの静的解析
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        args: ['-x']  # 外部ソースのチェックも有効化
+
+  # シェルスクリプトのフォーマット
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.12.0-2
+    hooks:
+      - id: shfmt
+        args: ['-i', '2', '-ci']  # インデント2スペース、switch文のcaseもインデント


### PR DESCRIPTION
pre-commit-hooksを最新バージョンに更新し、シェルスクリプトの
品質向上のための追加hookを有効化。

## 更新内容
- pre-commit-hooks: v2.3.0 → v6.0.0
- shellcheck有効化: v0.11.0.1（シェルスクリプトの静的解析）
- shfmt追加: v3.12.0-2（シェルスクリプトのフォーマット）

## 追加されたhook
- check-added-large-files: 1MB以上のファイル検出
- check-merge-conflict: マージコンフリクトマーカー検出
- check-executables-have-shebangs: 実行可能ファイルのシェバンチェック
- check-shebang-scripts-are-executable: シェバン付きスクリプトの実行権限チェック
- mixed-line-ending: 混在する改行コードの検出

これにより、コード品質の自動チェックが強化される。