### PR TITLE
feat: 開発環境を更新

### DIFF
--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -8,6 +8,7 @@ brew "git"
 brew "gh"
 brew "pre-commit"
 brew "vim"
+brew "neovim"
 brew "zsh"
 brew "gawk"
 brew "gnu-sed"
@@ -56,7 +57,7 @@ brew "awscli"
 
 ## Azure
 ## https://learn.microsoft.com/ja-jp/cli/azure/install-azure-cli-macos
-brew "azure-cli"
+# brew "azure-cli"
 
 # たわらさんのフォントシリーズ
 # https://github.com/yuru7/HackGen
@@ -78,10 +79,12 @@ cask "cursor"
 cask "claude"
 cask "claude-code"
 cask "chatgpt"
+cask "codex"
 
 # Infrastructure
 cask "google-drive"
 cask "google-japanese-ime"
+cask "azookey-desktop"
 cask "karabiner-elements"
 cask "raycast"
 cask "zoom"
@@ -90,7 +93,7 @@ cask "android-platform-tools"
 # Programming
 # cask "docker"
 cask "rancher"  # Docker Desktop とコンフリクトするのでどっちかにする
-cask "warp"
+cask "ghostty"
 # cask "lm-studio"
 # cask "tableplus"
 

--- a/other.sh
+++ b/other.sh
@@ -28,5 +28,4 @@ mise use -g node@latest
 
 # Node.jsのインストールを待機してから npm パッケージをインストール
 echo "📦 Installing global npm packages..."
-npm i -g @openai/codex
 npm i -g @dataform/cli


### PR DESCRIPTION
- ターミナルをwarpからghosttyへ変更
- neovimを追加
- 日本語入力にazookey-desktopを追加（google-japanese-imeも残す）
- azure-cliを未使用のためコメントアウト
- codexをbrew caskに追加し、npm経由のインストールを削除

https://claude.ai/code/session_01BcAP69VKcsvJfpxHRSXwTm