### PR TITLE
feat(brew): add DroidDock

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ $ task setup-all
 $ rm -r ./bin # Homebrew経由で go-task インストール済のため、バイナリからインストールしたものは消す
 ```
 
-> [!NOTE]
-> [DroidDock](https://rajivm1991.github.io/DroidDock/) がbrewでのインストールに対応していないので手動で落とす必要アリ
-
-
 ## Directory Structure
 ```bash
 $ tree -aF -L 4 --dirsfirst -I .git -I .gitignore -I .DS_Store

--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -110,3 +110,8 @@ cask "spotify"
 # cask "cold-turkey-blocker"
 # cask "tunnelblick"
 # cask "microsoft-remote-desktop"
+
+# DroidDock
+tap "rajivm1991/droiddock"
+cask "rajivm1991/droiddock/droiddock"
+


### PR DESCRIPTION
## Summary
- DroidDock (Android device management tool) を Brewfile に追加
- 外部 tap の cask はフルパス指定 (`rajivm1991/droiddock/droiddock`) で記述

## Test plan
- [ ] `brew bundle --file=brewfiles/Brewfile` で DroidDock がインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)