### PR TITLE
fix(zshrc): shellcheck エラーを修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+# shellcheck disable=SC1090,SC1091
 export CLICOLOR=1
 autoload -Uz compinit && compinit
 
@@ -64,10 +66,10 @@ alias gcm='git switch main'
 alias gsl='git stash list'
 
 ## gcloud
-alias gcloud-switch='switch_gcloud_configuration'
+alias gcactivate='switch_gcloud_configuration'
 
 function switch_gcloud_configuration() {
-  gcloud config configurations activate $(gcloud config configurations list | awk '{print $1}' | grep -v NAME | peco)
+  gcloud config configurations activate "$(gcloud config configurations list | awk '{print $1}' | grep -v NAME | peco)"
 }
 # ============================================================
 
@@ -90,7 +92,7 @@ setopt correct
 setopt pushd_ignore_dups
 
 # 移動した後は 'ls' する
-function chpwd() { ls -F }
+function chpwd() { ls -F; }
 
 if ! zplug check --verbose; then
   zplug install


### PR DESCRIPTION
## Summary

- `# shellcheck shell=bash` ディレクティブ追加・SC1090/SC1091 をグローバル無効化 (SC2148 解消)
- `gcloud-switch` エイリアスを `gcactivate` にリネーム
- `chpwd()` 関数の `}` 前にセミコロンを追加 (SC1083 解消)
- `gcloud` コマンドの `$()` をクォートで囲む (SC2046 解消)

## Test plan

- [ ] pre-commit run --all-files が通ること
- [ ] CI (shellcheck) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)