### PR TITLE
feat: Skillfile で外部スキルを宣言的に管理

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,7 +55,20 @@ tasks:
         while IFS= read -r line || [ -n "$line" ]; do
           [[ "$line" =~ ^[[:space:]]*# ]] && continue
           [[ -z "${line//[[:space:]]/}" ]] && continue
-          gh skill install $line --agent claude-code --scope user --force
+          repo=$(echo "$line" | awk '{print $1}')
+          skill=$(echo "$line" | awk '{print $2}')
+          if [ -z "$skill" ]; then
+            # スキル名省略時: リポジトリの全スキルを動的にインストール
+            namespaces=$(gh api "repos/$repo/contents/skills" --jq '.[].name' 2>/dev/null)
+            for ns in $namespaces; do
+              skill_names=$(gh api "repos/$repo/contents/skills/$ns" --jq '.[].name' 2>/dev/null)
+              for s in $skill_names; do
+                gh skill install "$repo" "$ns/$s" --agent claude-code --scope user --force
+              done
+            done
+          else
+            gh skill install $line --agent claude-code --scope user --force
+          fi
         done < claude_global/Skillfile
 
   skills-update:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,6 +16,7 @@ tasks:
       - task: brew
       - task: brew-mas
       - task: link
+      - task: skills
       - task: gui
       - task: git
       - task: other
@@ -46,6 +47,20 @@ tasks:
   git:
     desc: "Configuring GitHub"
     cmd: sh ./github.sh
+
+  skills:
+    desc: "Skillfile から外部スキルをインストール"
+    cmds:
+      - |
+        while IFS= read -r line || [ -n "$line" ]; do
+          [[ "$line" =~ ^[[:space:]]*# ]] && continue
+          [[ -z "${line//[[:space:]]/}" ]] && continue
+          gh skill install $line --agent claude-code --scope user --force
+        done < claude_global/Skillfile
+
+  skills-update:
+    desc: "インストール済みの外部スキルをアップデート"
+    cmd: gh skill update --agent claude-code --scope user
 
   other:
     desc: "Configuring others"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,20 +55,7 @@ tasks:
         while IFS= read -r line || [ -n "$line" ]; do
           [[ "$line" =~ ^[[:space:]]*# ]] && continue
           [[ -z "${line//[[:space:]]/}" ]] && continue
-          repo=$(echo "$line" | awk '{print $1}')
-          skill=$(echo "$line" | awk '{print $2}')
-          if [ -z "$skill" ]; then
-            # スキル名省略時: リポジトリの全スキルを動的にインストール
-            namespaces=$(gh api "repos/$repo/contents/skills" --jq '.[].name' 2>/dev/null)
-            for ns in $namespaces; do
-              skill_names=$(gh api "repos/$repo/contents/skills/$ns" --jq '.[].name' 2>/dev/null)
-              for s in $skill_names; do
-                gh skill install "$repo" "$ns/$s" --agent claude-code --scope user --force
-              done
-            done
-          else
-            gh skill install $line --agent claude-code --scope user --force
-          fi
+          gh skill install $line --agent claude-code --scope user --force
         done < claude_global/Skillfile
 
   skills-update:

--- a/claude_global/Skillfile
+++ b/claude_global/Skillfile
@@ -1,6 +1,8 @@
 # 外部スキルの宣言ファイル
-# 書式: <owner/repo> <skill-name>
+# 書式:
+#   <owner/repo>           → リポジトリの全スキルをインストール
+#   <owner/repo> <skill>   → 特定スキルのみインストール
 # インストール: task skills
 # 更新:         task skills-update
 
-google/skills cloud
+google/skills

--- a/claude_global/Skillfile
+++ b/claude_global/Skillfile
@@ -1,0 +1,6 @@
+# 外部スキルの宣言ファイル
+# 書式: <owner/repo> <skill-name>
+# インストール: task skills
+# 更新:         task skills-update
+
+google/skills cloud

--- a/claude_global/Skillfile
+++ b/claude_global/Skillfile
@@ -1,8 +1,9 @@
 # 外部スキルの宣言ファイル
-# 書式:
-#   <owner/repo>           → リポジトリの全スキルをインストール
-#   <owner/repo> <skill>   → 特定スキルのみインストール
+# 書式: <owner/repo> <skill-name>
 # インストール: task skills
 # 更新:         task skills-update
 
-google/skills
+google/skills cloud/gcloud
+google/skills cloud/bigquery-basics
+google/skills cloud/cloud-run-basics
+google/skills cloud/gemini-api

--- a/claude_global/skills/.gitignore
+++ b/claude_global/skills/.gitignore
@@ -1,0 +1,2 @@
+# gh skill install で管理される外部スキル（Skillfile から再インストール可能）
+cloud/

--- a/claude_global/skills/.gitignore
+++ b/claude_global/skills/.gitignore
@@ -1,2 +1,5 @@
 # gh skill install で管理される外部スキル（Skillfile から再インストール可能）
-cloud/
+bigquery-basics/
+cloud-run-basics/
+gcloud/
+gemini-api/


### PR DESCRIPTION
## Summary

- `claude_global/Skillfile` を追加し、`gh skill install` で管理する外部スキルを Brewfile パターンで宣言的に管理できるようにした
- `claude_global/skills/.gitignore` を追加し、外部スキルをgit追跡対象から除外
- `Taskfile.yml` に `task skills`（インストール）・`task skills-update`（更新）を追加、`setup-all` にも組み込み

**現在の Skillfile:**
- `google/skills cloud/gcloud`
- `google/skills cloud/bigquery-basics`
- `google/skills cloud/cloud-run-basics`
- `google/skills cloud/gemini-api`

## Test plan

- [ ] `task skills` が Skillfile の4スキルを正常にインストールできる
- [ ] `task skills-update` でスキルが更新できる
- [ ] `claude_global/skills/` に外部スキルが git 追跡されないことを確認（`git status` で untracked に出ない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)