### PR TITLE
fix: Brewfile の databricks を完全修飾名に変更

### DIFF
--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -69,7 +69,7 @@ brew "snowflake-cli"
 ## Databricks
 ## https://docs.databricks.com/aws/en/dev-tools/cli/install
 tap "databricks/tap"
-brew "databricks"
+brew "databricks/tap/databricks"
 
 # Secret Management
 # https://infisical.com/docs/cli/overview


### PR DESCRIPTION
## Summary

- `brew "databricks"` を `brew "databricks/tap/databricks"` に変更
- CI の pristine 環境では `brew bundle` が tap インストール前に formula を解決しようとするため、短縮名だと `No available formula with the name "databricks"` エラーが発生していた
- 外部 tap の formula は完全修飾名（`tap-owner/tap-name/formula-name`）で指定するのが Homebrew 公式ドキュメントの推奨パターン（Snowflake の `brew "snowflakedb/snowflake-cli/snowflake-cli"` と同じ書き方）

## 参考

- Homebrew issue #20448（Databricks チーム自身が同じエラーを報告）
- Homebrew issue #21311 / PR #21312（`brew bundle` の fetch タイミングのバグ、2025年12月修正）

## Test plan

- [x] CI が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)