### PR TITLE
feat: Claude Code 関連設定を更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *.swp
 brewfiles/*.lock.json
+.claude/worktrees
+.claude/settings.local.json

--- a/.zshrc
+++ b/.zshrc
@@ -83,7 +83,9 @@ alias gcd='git switch -C develop'
 alias gsl='git stash list'
 
 ## Claude Code / Codex
-alias claude-dang='claude --dangerously-skip-permissions'
+alias claude-dang='claude agents --allow-dangerously-skip-permissions'
+alias claude-compress='HEADROOM_TELEMETRY=off headroom wrap claude'
+alias codex-compress='HEADROOM_TELEMETRY=off headroom wrap codex'
 alias ccc='cat ~/.claude/settings.json'
 alias vcc='vi ~/.claude/settings.json'
 alias codex-dang='codex --dangerously-bypass-approvals-and-sandbox'

--- a/claude_global/settings.json
+++ b/claude_global/settings.json
@@ -30,7 +30,7 @@
       "Bash(gh api -X DELETE*)",
       "Bash(sudo *)"
     ],
-    "defaultMode": "plan"
+    "defaultMode": "auto"
   },
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
## Summary

- `.gitignore` に `.claude/worktrees` と `.claude/settings.local.json` を追加
- `claude-dang` エイリアスを `claude agents --allow-dangerously-skip-permissions` に更新
- `claude-compress` / `codex-compress` エイリアスを追加（headroom wrap 経由）
- `claude_global/settings.json` の `defaultMode` を `plan` → `auto` に変更

## Test plan

- [x] `source ~/.zshrc` 後に `alias | grep claude` でエイリアスが正しく反映されていることを確認
- [x] Claude Code 起動時にデフォルトモードが `auto` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)