### PR TITLE
fix(ci): CIの不具合修正&機能強化

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,12 @@ on:
       - other.sh
       - Taskfile.yml
       - claude_global/Skillfile
+  workflow_dispatch:
+    inputs:
+      full_brew_test:
+        description: "Homebrew 全量テスト（全パッケージを検証）"
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -50,6 +56,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       # https://github.com/arduino/setup-task
       - name: Install Task (go-task)
@@ -77,14 +85,49 @@ jobs:
           task link
           ls -al $HOME/.config
 
-      - name: Homebrew test (without mas)
-        if: contains(needs.setup.outputs.changed_files, '.github/workflows/actions.yml') || contains(needs.setup.outputs.changed_files, 'brewfiles/Brewfile') || contains(needs.setup.outputs.changed_files, 'other.sh')
+      # PR・workflow_dispatch（full_brew_test=false）では追加パッケージのみインストール
+      - name: Homebrew test (差分のみ)
+        if: >-
+          !inputs.full_brew_test &&
+          (contains(needs.setup.outputs.changed_files, '.github/workflows/actions.yml') ||
+           contains(needs.setup.outputs.changed_files, 'brewfiles/Brewfile') ||
+           contains(needs.setup.outputs.changed_files, 'other.sh'))
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
+          else
+            BASE_SHA=$(git rev-parse HEAD^)
+          fi
+          git diff "${BASE_SHA}"...HEAD -- brewfiles/Brewfile \
+            | grep '^+[^+]' | sed 's/^+//' \
+            > /tmp/Brewfile.diff
+          if [ -s /tmp/Brewfile.diff ]; then
+            echo "📦 追加パッケージをインストール中..."
+            brew bundle --file=/tmp/Brewfile.diff
+          else
+            echo "✅ Brewfile に追加パッケージなし、スキップ"
+          fi
+
+      # workflow_dispatch で full_brew_test=true のときのみ全量テスト
+      - name: Homebrew test (全量)
+        if: github.event_name == 'workflow_dispatch' && inputs.full_brew_test
         run: task brew
 
       - name: Skills test
         if: contains(needs.setup.outputs.changed_files, 'claude_global/Skillfile') || contains(needs.setup.outputs.changed_files, 'Taskfile.yml')
         continue-on-error: true
         run: task skills
+
+      # brew が走らなかった場合でも mise を保証（other.sh が mise に依存するため）
+      - name: Ensure mise is installed
+        if: >-
+          contains(needs.setup.outputs.changed_files, '.github/workflows/actions.yml') ||
+          contains(needs.setup.outputs.changed_files, 'Taskfile.yml') ||
+          contains(needs.setup.outputs.changed_files, 'other.sh')
+        run: command -v mise || brew install mise
 
       - name: Other test
         if: contains(needs.setup.outputs.changed_files, '.github/workflows/actions.yml') || contains(needs.setup.outputs.changed_files, 'Taskfile.yml') || contains(needs.setup.outputs.changed_files, 'other.sh')

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,12 +23,16 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       changed_files: ${{ steps.set-changed-files.outputs.changed_files }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # https://github.com/tj-actions/changed-files
       - name: Get changed files
@@ -57,6 +61,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       # https://github.com/arduino/setup-task
@@ -86,6 +91,7 @@ jobs:
           ls -al $HOME/.config
 
       # PR・workflow_dispatch（full_brew_test=false）では追加パッケージのみインストール
+      # inputs.* は type: boolean で実際の boolean 値を返すため !inputs.full_brew_test は安全
       - name: Homebrew test (差分のみ)
         if: >-
           !inputs.full_brew_test &&


### PR DESCRIPTION
## Summary

- **mise 未インストール問題の修正**: brew が走らない PR（link.sh のみ変更等）でも `task other` 実行前に `command -v mise || brew install mise` で mise を保証
- **Homebrew テストの高速化**: Brewfile の差分（追加行のみ）を一時ファイルに書き出して `brew bundle` することで、全量インストールを回避
- **workflow_dispatch オプションの追加**: `full_brew_test=true` を指定したときだけ `task brew` で全量テストを実行
- **セキュリティ強化**: zizmor レビューで検出された Medium 2件を修正

## 変更詳細

| 変更 | 内容 |
|------|------|
| `Ensure mise is installed` ステップ追加 | `command -v mise \|\| brew install mise` で冪等に担保 |
| `Homebrew test (差分のみ)` | git diff でベース SHA との差分から追加行を抽出し一時 Brewfile を作成 |
| `Homebrew test (全量)` | `workflow_dispatch` + `full_brew_test=true` のときのみ実行 |
| `fetch-depth: 0` | git diff でベース SHA を参照するために追加 |
| `persist-credentials: false` | 両チェックアウトに追加し GITHUB_TOKEN の残存を防止（zizmor artipacked） |
| `setup` ジョブ permissions 明示 | `permissions: contents: read` を追加（トップレベル `{}` の継承を明確化） |

## Test plan

- [ ] link.sh のみ変更する PR で `Ensure mise is installed` → `Other test` が成功することを確認
- [ ] Brewfile にパッケージを追加した PR で `Homebrew test (差分のみ)` が差分のみインストールすることを確認
- [ ] Brewfile を変更せず他ファイルのみ変更した PR で `Homebrew test (差分のみ)` が「追加パッケージなし」でスキップされることを確認
- [ ] GitHub Actions UI から `workflow_dispatch` で `full_brew_test=true` を指定し全量テストが走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)