### PR TITLE
test(ci): テストケース2 — Brewfile 差分のみインストールされること

### DIFF
--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -128,6 +128,8 @@ cask "spotify"
 # cask "tunnelblick"
 # cask "aqua-voice"
 
+brew "jq"
+
 # DroidDock
 tap "rajivm1991/droiddock"
 cask "rajivm1991/droiddock/droiddock"


### PR DESCRIPTION
## テスト目的

`brewfiles/Brewfile` に1パッケージ追加した PR で、追加分だけ `brew bundle` されることを検証する。

## 変更内容

- `brewfiles/Brewfile` に `brew "jq"` を1行追加

## 確認ポイント

- [x] **Homebrew test (差分のみ)** ステップが実行されること
- [x] ステップログに「📦 追加パッケージをインストール中...」と表示され、`jq` のみインストールされること（全 Brewfile ではない）
- [x] ジョブの所要時間が全量テストより大幅に短いこと

## テスト完了後

このブランチと PR はクローズ・削除して問題ない。