### PR TITLE
fix: headroom関連の修正

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -128,12 +128,14 @@ jobs:
         run: task skills
 
       # brew が走らなかった場合でも mise を保証（other.sh が mise に依存するため）
-      - name: Ensure mise is installed
+      - name: Ensure mise and uv are installed
         if: >-
           contains(needs.setup.outputs.changed_files, '.github/workflows/actions.yml') ||
           contains(needs.setup.outputs.changed_files, 'Taskfile.yml') ||
           contains(needs.setup.outputs.changed_files, 'other.sh')
-        run: command -v mise || brew install mise
+        run: |
+          command -v mise || brew install mise
+          command -v uv || brew install uv
 
       - name: Other test
         if: contains(needs.setup.outputs.changed_files, '.github/workflows/actions.yml') || contains(needs.setup.outputs.changed_files, 'Taskfile.yml') || contains(needs.setup.outputs.changed_files, 'other.sh')

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ brewfiles/*.lock.json
 .claude/settings.local.json
 .serena/*
 !.serena/project.yml
+!.serena/serena_config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 brewfiles/*.lock.json
 .claude/worktrees
 .claude/settings.local.json
+.serena/*
+!.serena/project.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "dotfiles"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- bash
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/.serena/serena_config.yml
+++ b/.serena/serena_config.yml
@@ -1,0 +1,3 @@
+# Serena global configuration managed by dotfiles.
+# Keep the dashboard available, but prevent opening a localhost browser tab on each session start.
+web_dashboard_open_on_launch: false

--- a/.zshrc
+++ b/.zshrc
@@ -81,8 +81,8 @@ alias gsl='git stash list'
 
 ## Claude Code / Codex
 alias claude-dang='claude agents --allow-dangerously-skip-permissions'
-alias claude-compress='HEADROOM_TELEMETRY=off headroom wrap claude --no-rtk'
-alias codex-compress='HEADROOM_TELEMETRY=off headroom wrap codex --no-rtk'
+alias claude-compress='HEADROOM_TELEMETRY=off headroom wrap claude --no-context-tool'
+alias codex-compress='HEADROOM_TELEMETRY=off headroom wrap codex --no-context-tool'
 alias ccc='cat ~/.claude/settings.json'
 alias vcc='vi ~/.claude/settings.json'
 alias codex-dang='codex --dangerously-bypass-approvals-and-sandbox'

--- a/.zshrc
+++ b/.zshrc
@@ -81,8 +81,8 @@ alias gsl='git stash list'
 
 ## Claude Code / Codex
 alias claude-dang='claude agents --allow-dangerously-skip-permissions'
-alias claude-compress='HEADROOM_TELEMETRY=off headroom wrap claude'
-alias codex-compress='HEADROOM_TELEMETRY=off headroom wrap codex'
+alias claude-compress='HEADROOM_TELEMETRY=off headroom wrap claude --no-rtk'
+alias codex-compress='HEADROOM_TELEMETRY=off headroom wrap codex --no-rtk'
 alias ccc='cat ~/.claude/settings.json'
 alias vcc='vi ~/.claude/settings.json'
 alias codex-dang='codex --dangerously-bypass-approvals-and-sandbox'

--- a/link.sh
+++ b/link.sh
@@ -74,6 +74,10 @@ for entry in "$HERE/claude_global/"*; do
   backup_and_link "$entry" "$CLAUDEDIR/$name" ".claude/$name"
 done
 
+SERENADIR="$HOME/.serena"
+mkdir -p "$SERENADIR"
+backup_and_link "$HERE/.serena/serena_config.yml" "$SERENADIR/serena_config.yml" ".serena/serena_config.yml"
+
 # ~/.claude/skills/ は実ディレクトリとして確保し、ローカルスキルのみ個別リンク
 # （外部スキルは task skills で直接インストールされる）
 SKILLSDIR="$CLAUDEDIR/skills"

--- a/other.sh
+++ b/other.sh
@@ -15,13 +15,13 @@ fi
 # =============================================================================
 # Python実行環境の構築
 # =============================================================================
-# miseで最新のPythonをインストール＆グローバルなバージョンに設定
+# miseでPython 3.13をインストール＆グローバルなバージョンに設定
 echo "📦 Installing Python with mise..."
-mise use -g python@latest
+mise use -g python@3.13
 
 # uv tool でグローバルな Python ツールをインストール
 echo "📦 Installing Python tools with uv..."
-uv tool install "headroom-ai[all]"
+uv tool install --python 3.13 "headroom-ai[all]"
 
 # =============================================================================
 # Node.js実行環境の構築

--- a/other.sh
+++ b/other.sh
@@ -19,6 +19,10 @@ fi
 echo "📦 Installing Python with mise..."
 mise use -g python@latest
 
+# uv tool でグローバルな Python ツールをインストール
+echo "📦 Installing Python tools with uv..."
+uv tool install "headroom-ai[all]"
+
 # =============================================================================
 # Node.js実行環境の構築
 # =============================================================================

--- a/other.sh
+++ b/other.sh
@@ -21,7 +21,7 @@ mise use -g python@latest
 
 # uv tool でグローバルな Python ツールをインストール
 echo "📦 Installing Python tools with uv..."
-"$(brew --prefix)/bin/uv" tool install "headroom-ai[all]"
+uv tool install "headroom-ai[all]"
 
 # =============================================================================
 # Node.js実行環境の構築

--- a/other.sh
+++ b/other.sh
@@ -21,7 +21,7 @@ mise use -g python@latest
 
 # uv tool でグローバルな Python ツールをインストール
 echo "📦 Installing Python tools with uv..."
-uv tool install "headroom-ai[all]"
+"$(brew --prefix)/bin/uv" tool install "headroom-ai[all]"
 
 # =============================================================================
 # Node.js実行環境の構築


### PR DESCRIPTION
## 概要

- `headroom-ai[all]` を `other.sh` で `uv tool install` するように追加
- `headroom-ai[all]` のビルドが Python 3.14 で失敗するため、Python を 3.13 に固定し、`uv tool install --python 3.13` でインストール
- `claude-compress` / `codex-compress` の `headroom wrap` に `--no-context-tool` を付与
- Serena のプロジェクト設定を追加し、`serena_config.yml` でセッション開始時に localhost の dashboard を自動で開かないように設定
- `task link` で `~/.serena/serena_config.yml` も dotfiles 管理下の設定へリンクするように追加
- CI の `Other test` 前に `mise` と `uv` を明示的に用意する step を追加
- 不要になった `.codex/config.toml` を削除

## CI 対応

`other.sh` では `uv tool install "headroom-ai[all]"` を使います。
CI では `task brew` が実行されないケースでも `task other` が通るよう、`.github/workflows/actions.yml` の step を `Ensure mise and uv are installed` に変更し、`mise` と `uv` をそれぞれ `command -v ... || brew install ...` で保証します。

また、macOS runner の `python@latest` が Python 3.14 を選ぶと `headroom-ai[all]` の PyO3/maturin 系ビルドが失敗するため、`other.sh` では Python 3.13 に固定しています。

## 確認

- `zsh -n .zshrc`
- `zsh -n link.sh`
- `zsh -n other.sh`
- `.serena/serena_config.yml` の YAML 読み込み
- `.github/workflows/actions.yml` の YAML 読み込み
- `pre-commit run --files other.sh`
- `pre-commit run --files .github/workflows/actions.yml`