### PR TITLE
chore: empirical-prompt-tuning の説明を短縮

### DIFF
--- a/claude_global/skills/empirical-prompt-tuning/SKILL.md
+++ b/claude_global/skills/empirical-prompt-tuning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: empirical-prompt-tuning
-description: agent 向けテキスト指示（skill / slash command / task プロンプト / CLAUDE.md 節 / コード生成プロンプト）を、バイアスを排した実行者に動かしてもらい、両面（実行者の自己申告 + 指示側メトリクス）で評価して反復改善する手法。改善が頭打ちになるまで回す。プロンプトや skill を新規作成・大幅改訂した直後、またはエージェントの挙動が期待通りにならない原因を指示側の曖昧さに求めたいときに使う。
+description: agent 向け指示や skill を実行評価で反復改善する。新規作成・大幅改訂後、または挙動不良の原因を指示の曖昧さに求めたいときに使う。
 ---
 
 # Empirical Prompt Tuning


### PR DESCRIPTION
## 概要

- `empirical-prompt-tuning` skill の frontmatter `description` を短縮
- `/doctor` で skill listing の説明文予算超過が出にくくなるよう、トリガー判定に必要な要点だけを残した

## 影響

- skill 本文やワークフローは変更なし
- 一覧表示時の token 使用量を削減

## 検証

- `pre-commit run --files claude_global/skills/empirical-prompt-tuning/SKILL.md`
