### PR TITLE
fix: gh skill update の --agent フラグを削除

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,7 +60,7 @@ tasks:
 
   skills-update:
     desc: "インストール済みの外部スキルをアップデート"
-    cmd: gh skill update --agent claude-code --scope user
+    cmd: gh skill update --all
 
   nonbrew:
     desc: "Installing tools not managed by Homebrew"


### PR DESCRIPTION
## 概要

- `gh skill update` は初期実装（[cli/cli#13165](https://github.com/cli/cli/pull/13165)）から `--agent` / `--scope` フラグを持っておらず、インストール済みスキルのディレクトリを自動検出する仕様だった
- `skills-update` タスクのコマンドを `gh skill update --all` に修正した