### PR TITLE
feat: cosense-cli スキルを導入する

### DIFF
--- a/claude_global/settings.json
+++ b/claude_global/settings.json
@@ -43,7 +43,8 @@
     "commit-commands@claude-plugins-official": true,
     "codex@openai-codex": true,
     "security-guidance@claude-plugins-official": true,
-    "exa@claude-plugins-official": true
+    "exa@claude-plugins-official": true,
+    "cosense-cli@cosense-cli": true
   },
   "extraKnownMarketplaces": {
     "superpowers-marketplace": {
@@ -68,6 +69,12 @@
       "source": {
         "source": "github",
         "repo": "openai/codex-plugin-cc"
+      }
+    },
+    "cosense-cli": {
+      "source": {
+        "source": "github",
+        "repo": "helpfeel/cosense-cli"
       }
     }
   },

--- a/nonbrew.sh
+++ b/nonbrew.sh
@@ -18,6 +18,9 @@ npm install -g @dataform/cli
 # https://github.com/andrewyng/context-hub
 npm install -g @aisuite/chub
 
+# https://github.com/helpfeel/cosense-cli
+npm install -g @helpfeel/cosense-cli
+
 # =============================================================================
 # uv 経由でのインストール
 # =============================================================================


### PR DESCRIPTION
## 概要

- `nonbrew.sh` に `@helpfeel/cosense-cli` のグローバルインストールを追加
- `claude_global/settings.json` に cosense-cli プラグインを有効化

## 変更内容

- Cosense（旧Scrapbox）のページ読み取り・調査・編集ができるエージェントスキルを導入
- CLI（`@helpfeel/cosense-cli`）をグローバルインストールすることでスキルが動作可能になる
- 認証は `cosense login https://scrapbox.io` でPATを設定（初回のみ手動操作が必要）

## テスト計画

- [x] `task nonbrew` を実行して `cosense --help` が動くことを確認
- [x] Claude Code で「Cosenseで〇〇調べて」と入力してスキルが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)