### PR TITLE
fix(ci): go-task公式セットアップActionに移行

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -64,12 +64,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      # https://github.com/arduino/setup-task
+      # https://github.com/go-task/setup-task
       - name: Install Task (go-task)
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
         with:
           version: 3.x
-          repo-token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Taskfile syntax check
         if: contains(needs.setup.outputs.changed_files, 'Taskfile.yml')


### PR DESCRIPTION
## 概要
- `arduino/setup-task` から公式の `go-task/setup-task` に置き換え
- `repo-token: secrets.ACCESS_TOKEN` を削除し、公式 action 側の `${{ github.token }}` default を利用

## 背景
Dependabot PR では repository secret が渡らず、`arduino/setup-task` が未認証で GitHub API を呼び出して rate limit に到達していた。

## 確認
- `YAML.load_file` による workflow YAML 構文確認
- pre-commit hooks 通過