### PR TITLE
chore: Context7 MCPをAPM管理に追加

### DIFF
--- a/apm/apm.lock.yaml
+++ b/apm/apm.lock.yaml
@@ -1,5 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-07-23T07:53:40+00:00'
+generated_at: '2026-07-24T01:26:33.935096+00:00'
 apm_version: 0.26.0
 dependencies:
 - repo_url: google/skills
@@ -1367,6 +1367,15 @@ deployments:
   content_hash: sha256:a86085ee2f532f594dc37b1fdee40b9c5f404627196b9278bd0e5073a28ca682
 - kind: uri
   target: mcp
+  value: context7
+  runtime: claude
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: null
+- kind: uri
+  target: mcp
   value: exa
   runtime: claude
   scope: project
@@ -1378,6 +1387,15 @@ deployments:
   target: mcp
   value: findy-library
   runtime: claude
+  scope: project
+  owners:
+  - .
+  active_owner: .
+  content_hash: null
+- kind: uri
+  target: mcp
+  value: context7
+  runtime: codex
   scope: project
   owners:
   - .
@@ -1402,9 +1420,15 @@ deployments:
   active_owner: .
   content_hash: null
 mcp_servers:
+- context7
 - exa
 - findy-library
 mcp_configs:
+  context7:
+    name: context7
+    transport: http
+    registry: false
+    url: https://mcp.context7.com/mcp
   exa:
     name: exa
     transport: http
@@ -1417,8 +1441,10 @@ mcp_configs:
     url: https://lib.findy.co.jp/mcp
 mcp_target_servers:
   claude:
+  - context7
   - exa
   - findy-library
   codex:
+  - context7
   - exa
   - findy-library

--- a/apm/apm.yml
+++ b/apm/apm.yml
@@ -32,6 +32,10 @@ dependencies:
     - snhryt-neo/dotfiles/skills/imagegen
     - snhryt-neo/dotfiles/skills/semantic-generation
   mcp:
+    - name: context7
+      registry: false
+      transport: http
+      url: https://mcp.context7.com/mcp
     - name: findy-library
       registry: false
       transport: http


### PR DESCRIPTION
## 概要

Context7 MCPをAPMの管理対象に追加しました。

## 背景

MCPをAPMへ移行した際、Context7だけがClaude Codeのユーザー設定に直接登録されたまま残っていました。`apm.yml` とロックファイルへ追加し、Claude CodeとCodexの両方へAPM経由で展開できる状態にします。

既存のClaude Codeユーザー設定からContext7を削除する作業は、このPRには含めません。

## 確認内容

- `pre-commit run --files apm/apm.yml apm/apm.lock.yaml`
- `apm install --only mcp --target claude,codex --root <temporary-directory> --frozen --dry-run --no-policy --no-audit`
- 隔離した一時ディレクトリでAPMが生成したロックファイルとの差分一致確認
- `git diff --check -- apm/apm.yml apm/apm.lock.yaml`