### PR TITLE
feat: ターミナルエディタ fresh を管理対象に追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ $ tree -aF -L 4 --dirsfirst -I .git -I .gitignore -I .DS_Store
 ├── claude_global/ # ~/.claude/ 直下に一括リンクされるファイル群
 │   ├── CLAUDE.md           # 全プロジェクト共通の作業規約（~/.claude/CLAUDE.md と ~/.codex/AGENTS.md にリンク）
 │   └── settings.json       # Claude Code のグローバル設定（~/.claude/settings.json にリンク）
+├── fresh/ # ターミナルエディタ fresh の設定（config.json のみリンクし、自動生成物は対象外）
+│   └── config.json
 ├── git/ # グローバルなGitの設定
 │   ├── templates/
 │   │   ├── secrets/ # git init時の git-secrets 自動追加設定

--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -80,7 +80,7 @@ brew "databricks/tap/databricks"
 # Terminal editor
 # https://github.com/sinelaw/fresh
 tap "sinelaw/fresh"
-brew "fresh" # モーダル操作なしで編集でき、worktree ごとにエージェントを並走させられる
+brew "fresh" # ターミナルエディタ
 
 # Secret Management
 # https://infisical.com/docs/cli/overview

--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -9,6 +9,10 @@ brew "gh"
 brew "pre-commit"
 brew "vim"
 brew "neovim"
+# モーダル操作を必要としないターミナルエディタ。
+# ディレクトリ単位のセッションを常駐させ、worktree ごとにエージェントを並走させる用途で使う。
+tap "sinelaw/fresh"
+brew "fresh"
 brew "zsh"
 brew "gawk"
 brew "gnu-sed"

--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -9,10 +9,6 @@ brew "gh"
 brew "pre-commit"
 brew "vim"
 brew "neovim"
-# モーダル操作を必要としないターミナルエディタ。
-# ディレクトリ単位のセッションを常駐させ、worktree ごとにエージェントを並走させる用途で使う。
-tap "sinelaw/fresh"
-brew "fresh"
 brew "zsh"
 brew "gawk"
 brew "gnu-sed"
@@ -80,6 +76,11 @@ brew "snowflake-cli"
 ## https://docs.databricks.com/aws/en/dev-tools/cli/install
 tap "databricks/tap"
 brew "databricks/tap/databricks"
+
+# Terminal editor
+# https://github.com/sinelaw/fresh
+tap "sinelaw/fresh"
+brew "fresh" # モーダル操作なしで編集でき、worktree ごとにエージェントを並走させられる
 
 # Secret Management
 # https://infisical.com/docs/cli/overview

--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -80,7 +80,7 @@ brew "databricks/tap/databricks"
 # Terminal editor
 # https://github.com/sinelaw/fresh
 tap "sinelaw/fresh"
-brew "fresh" # ターミナルエディタ
+brew "fresh"
 
 # Secret Management
 # https://infisical.com/docs/cli/overview

--- a/fresh/config.json
+++ b/fresh/config.json
@@ -1,0 +1,6 @@
+{
+  "locale": "ja",
+  "theme": "dark",
+  "check_for_updates": false,
+  "self_update": false
+}

--- a/mise.toml
+++ b/mise.toml
@@ -16,6 +16,10 @@ dotfiles.default_mode = "symlink"
 "~/.config/sheldon" = "sheldon"
 "~/.config/ccstatusline" = "ccstatusline"
 
+# fresh は同じディレクトリへ型宣言やテーマを自動生成するため、ディレクトリごとではなく設定ファイルだけをリンクする。
+# check_for_updates は匿名テレメトリ送信を兼ねるため false、self_update は Homebrew の管理と競合するため false にしている。
+"~/.config/fresh/config.json" = "fresh/config.json"
+
 # Claude Code のグローバル設定は、claude_global/ へ追加したファイルも自動的に管理対象に含める。
 "~/.claude/*" = "claude_global/*"
 

--- a/mise.toml
+++ b/mise.toml
@@ -15,9 +15,6 @@ dotfiles.default_mode = "symlink"
 "~/.config/karabiner" = "karabiner"
 "~/.config/sheldon" = "sheldon"
 "~/.config/ccstatusline" = "ccstatusline"
-
-# fresh は同じディレクトリへ型宣言やテーマを自動生成するため、ディレクトリごとではなく設定ファイルだけをリンクする。
-# check_for_updates は匿名テレメトリ送信を兼ねるため false、self_update は Homebrew の管理と競合するため false にしている。
 "~/.config/fresh/config.json" = "fresh/config.json"
 
 # Claude Code のグローバル設定は、claude_global/ へ追加したファイルも自動的に管理対象に含める。


### PR DESCRIPTION
## 背景・概要

エージェントの出力を手で直すたびにターミナルとVSCodeを往復しており、その切り替えが手間になっていた。既存環境にはtmuxやzellijのような多重化層がなく、複数のworktreeで並行作業する際にセッションを保持する仕組みも持っていない。

ターミナルエディタ fresh をパッケージと設定の管理対象へ加えることで、この2つをまとめて解消する。fresh はモーダル操作を必要とせず、標準的なキーバインドとマウスで編集できる。LSPを内蔵し、統合ターミナルでコーディングエージェントを走らせながら、隣のペインでその出力を直接手直しできる。ディレクトリ単位でデーモンが常駐するため、worktreeごとのセッションがそのまま残る。

設定は `~/.config/fresh` へ型宣言やテーマが自動生成されるため、ディレクトリごとではなく `config.json` だけをリンクする。既存の `locale` と `theme` は現在の内容をそのまま引き継いだうえで、以下の2項目を無効化した。

| 項目 | 値 | 理由 |
| :--- | :--- | :--- |
| `check_for_updates` | `false` | 更新確認と同じスイッチで匿名テレメトリ（バージョン、OS/アーキテクチャ、`TERM`）を送信するため |
| `self_update` | `false` | Homebrew による更新管理と競合するため |

## レビューしてほしい観点

- ディレクトリ全体ではなく `config.json` 単体をリンクする方針が、自動生成物を管理対象から外す手段として妥当か
- `self_update` の無効化により、更新経路を `brew upgrade` に一本化する判断でよいか

## 補足

- fresh 0.4.10 はすでにローカルへ導入済みだったが Brewfile に未記載だったため、あわせて宣言化した
- ライセンスは GPL-2.0。Homebrew formula の `license "Apache-2.0"` という記載は誤りで、リポジトリの LICENSE 本体は GNU GPL Version 2
- `task link` の実行後、`~/.config/fresh/config.json` がリポジトリ内の実体への symlink に置き換わる
- formula 名は `fresh`。`fresh-editor` は同一 formula のエイリアス
