### PR TITLE
feat: batの設定をコピペしやすい構成に見直し

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,7 @@
 export CLICOLOR=1
+# manページを構文ハイライト付きで読む。
+# macOSのnroffはバックスペースによる重ね打ちで太字を表現するため、col で落としてからbatへ渡す
+export MANPAGER="sh -c 'col -bx | bat -plman'"
 export TMPDIR="$HOME/.tmp"
 
 # ======================================================================
@@ -53,7 +56,8 @@ setopt pushd_ignore_dups
 alias cd='z'
 alias ls='lsd -F --group-directories-first'
 alias find='fd'
-alias cat='bat'
+# コピペのじゃまになる行番号やGit変更マーカーを出さない。装飾つきで読むときはbatを直接叩く
+alias cat='bat -p'
 alias grep='rg'
 alias ps='procs'
 alias top='btm'

--- a/bat/config
+++ b/bat/config
@@ -1,10 +1,16 @@
---theme="Coldark-Dark"
+# ターミナルの明暗に追従させるため、テーマを固定せず明暗それぞれを指定する
+--theme-dark="Coldark-Dark"
+--theme-light="Coldark-Cold"
 
-# Show line numbers, Git modifications and file header (but no grid)
---style="numbers,changes,header"
+# 閲覧向けのデフォルト。コピペするときは -p で装飾を落とす
+--style="numbers,changes,header-filename,rule"
 
 # Use italic text on the terminal (not supported on all terminals)
 --italic-text=always
 
-# Use ".gitignore"-style highlighting for ".ignore" files
---map-syntax ".ignore:Git Ignore"
+# 色付きログを読むときに制御コードが化けるのを防ぐ
+--strip-ansi=auto
+
+# 標準の構文定義が拾わないファイル名を補う
+--map-syntax "Brewfile*:Ruby"
+--map-syntax "**/ghostty/config:INI"


### PR DESCRIPTION
## 背景・概要

bat の出力に含まれる行番号と Git 変更マーカーが、ターミナルからコードをコピーするときに一緒に選択されてしまい、貼り付け後の手直しが頻発していた。装飾を一律で捨てるとファイル閲覧時の利便性が落ちるため、コピペ用途と閲覧用途を呼び出し方で分ける方針にした。

`cat` エイリアスを `bat -p` に変更し、日常的な `cat` は装飾なし（構文ハイライトとページャは維持）にする。行番号や Git 変更マーカーつきで読みたいときは `bat` を直接叩く。

あわせて、設定を見直す過程で見つかった以下を調整した。

| 変更 | 理由 |
| :--- | :--- |
| `--theme` 固定をやめ `--theme-dark` / `--theme-light` を指定 | bat 0.26 のデフォルトは `--theme=auto` で、ターミナルの背景色を検出して自動で切り替わる |
| `--strip-ansi=auto` を追加 | 色付きログを読むときに制御コードがそのまま表示されるのを防ぐ |
| `--map-syntax "Brewfile*:Ruby"` を追加 | 標準の Ruby 定義は `Brewfile` 完全一致のみで、`Brewfile.mas` がハイライトされていなかった |
| `--map-syntax "**/ghostty/config:INI"` を追加 | ghostty の config は標準ではプレーンテキスト扱いになっていた |
| `--map-syntax ".ignore:Git Ignore"` を削除 | 標準の Git Ignore 定義に `.ignore` が含まれており冗長 |
| `MANPAGER` を設定 | man ページを構文ハイライト付きで読む |

## レビューしてほしい観点

- `cat` を装飾なしに倒す方針でよいか。`cz` / `ccc` / `ccdx` といった設定ファイル閲覧用のエイリアスも `cat` 経由のため、これらも行番号なしになる
- テーマ検出を `auto`（ターミナルの背景色を問い合わせ）にしている点。`--theme=auto:system` にすると macOS のシステムアピアランスを参照する方式に変わる。ターミナル側のテーマとシステム設定がずれる運用をするなら `auto` のままが正確

## 補足

- `MANPAGER` は bat の README にある `bat -plman` そのままだと、macOS の nroff がバックスペースの重ね打ちで太字を表現する都合で `NNAAMMEE` のように文字が二重になる。`col -bx` を挟んで解消している
- テーマ検出は出力がリダイレクトされている場合は働かず、`bat -f | ...` のように色を強制しつつパイプするケースでは bat の既定テーマにフォールバックする。対話利用では影響しない
- 反映には `task link` 実行後、`source ~/.zshrc` が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbA52wMV4vQ8M7AMXNBRdp
