### PR TITLE
feat: スクリーンショット・画面録画ツール Screendrop を管理対象に追加

### DIFF
--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -142,3 +142,8 @@ cask "spotify"
 # DroidDock
 tap "rajivm1991/droiddock"
 cask "rajivm1991/droiddock/droiddock"
+
+# Screendrop
+# https://github.com/fayazara/screendrop
+tap "fayazara/tap"
+cask "fayazara/tap/screendrop" # スクリーンショット・画面録画（要 macOS 26.4 以上）


### PR DESCRIPTION
## 背景・概要

スクリーンショットと画面録画をメニューバーから扱えるmacOSアプリ [Screendrop](https://github.com/fayazara/screendrop) を使いたい。GUIアプリはHomebrewで宣言的に管理しているため、公式が配布するcaskを `brewfiles/Brewfile` へ追加し、`task brew` で導入できるようにする。

記法は既存のDroidDockに合わせ、tapとcaskを併記した。

## レビューしてほしい観点

- 個人tapに依存する形での導入で問題ないか

## 補足

- 動作要件はmacOS 26.4以上のため、Brewfileにコメントで明記している