### PR TITLE
chore: Brewfile の AI 系 cask を現状に合わせて最新化

### DIFF
--- a/brewfiles/Brewfile
+++ b/brewfiles/Brewfile
@@ -105,9 +105,8 @@ cask "visual-studio-code"
 # AI
 cask "claude"
 cask "chatgpt"
-cask "claude-code"
+cask "claude-code@latest" # stable版の cask "claude-code" より更新が早い
 cask "codex"
-cask "codex-app"
 
 # Infrastructure
 cask "google-drive"


### PR DESCRIPTION
## 背景・概要

Brewfile の AI セクションに記載している cask が、Homebrew 側の提供状況および実際のローカル環境と乖離していたため、現状に合わせて整理する。

- `codex-app`: upstream で提供終了。cask 自体も deprecated（2027-07-12 に disable 予定）で、置き換え先は既に記載済みの `chatgpt` のため削除
- `claude-code` → `claude-code@latest`: 実際に導入しているのは `claude-code@latest`。Homebrew の Claude Code は cask 名でリリースチャンネルを選ぶ方式（`claude-code` = stable、`claude-code@latest` = latest）で、latest チャンネルを継続利用する方針としたため、宣言を実態に合わせる

## レビューしてほしい観点

- Brewfile の AI セクションが、現在利用しているアプリの構成と過不足なく一致しているか

## 補足

- Homebrew 経由の Claude Code は自動更新されない（`brew upgrade claude-code@latest` が必要）。Claude Code 自身に upgrade を実行させたい場合は環境変数 `CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE=1` を設定する
- `chatgpt-atlas`（OpenAI のブラウザ）がローカルに入っているが Brewfile には未記載。管理対象に含めるかは別途判断が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwLfFehtMChbmxbDFMtEu3