### PR TITLE
feat: X検索をAI Gateway経由にする

### DIFF
--- a/tools/xai-search-mcp/.dev.vars.example
+++ b/tools/xai-search-mcp/.dev.vars.example
@@ -1,2 +1,3 @@
 XAI_API_KEY=replace-me
+CLOUDFLARE_AI_GATEWAY_TOKEN=replace-me
 GITHUB_CLIENT_SECRET=replace-me

--- a/tools/xai-search-mcp/README.md
+++ b/tools/xai-search-mcp/README.md
@@ -7,6 +7,7 @@
   - Workers KV: OAuthのclient、grant、tokenの保存
   - Durable Object: 一時的なcallback stateの保存
 - X検索は[xAI Responses APIのX Search tool](https://docs.x.ai/developers/tools/x-search)を使う
+- xAIへのリクエストは[Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/usage/providers/grok/)を経由し、本文を保存せず利用量とコストを可視化する
 - クライアント側はAPMでRemote MCPを設定する: [`apm.yml`](../../apm/apm.yml)
 
 ## Setup
@@ -32,7 +33,20 @@ npx wrangler whoami --json
 https://xai-search-mcp.<workers.dev subdomain>.workers.dev
 ```
 
-### 3. GitHub OAuth Appを作成する
+### 3. AI Gatewayを作成する
+
+[Cloudflare DashboardのAI Gateway](https://dash.cloudflare.com/?to=/:account/ai/ai-gateway)で`xai-search-mcp`を作成する。
+
+| 設定 | 値 | 理由 |
+| :--- | :--- | :--- |
+| ログを収集 | ON | トークン、コスト、ステータス等を確認する。Workerが本文保存をリクエスト単位で無効化する |
+| キャッシュ レスポンス | OFF | 同一の検索語でも時点によってXの結果が変わるため |
+| レート制限リクエスト | OFF | ユーザー単位の厳密な上限を`BudgetGuard`で管理するため |
+| 認証済みゲートウェイ | ON | 第三者によるリクエストとログ汚染を防ぐため |
+
+認証トークンを作成し、後でWorker Secretへ登録する。AI Gatewayのトークンはアカウント単位の権限を持つため、リポジトリへ保存しない。[Authenticated Gateway](https://developers.cloudflare.com/ai-gateway/configuration/authentication/)
+
+### 4. GitHub OAuth Appを作成する
 
 [GitHub Developer settings](https://github.com/settings/applications/new)で、このMCP専用のOAuth Appを作成する。
 
@@ -48,7 +62,7 @@ https://xai-search-mcp.<workers.dev subdomain>.workers.dev
 gh api user --jq .id
 ```
 
-### 4. Workers KV namespaceを作成する
+### 5. Workers KV namespaceを作成する
 
 ```bash
 npx wrangler kv namespace create OAUTH_KV
@@ -56,7 +70,7 @@ npx wrangler kv namespace create OAUTH_KV
 
 出力されたnamespace IDを控える。Durable Objectは`wrangler.jsonc`のmigrationにより初回デプロイ時に作成されるため、事前操作は不要。
 
-### 5. `wrangler.jsonc`を設定する
+### 6. `wrangler.jsonc`を設定する
 
 取得した値を`wrangler.jsonc`へ設定する。
 
@@ -78,16 +92,17 @@ npx wrangler kv namespace create OAUTH_KV
 
 `PUBLIC_ORIGIN`、Client ID、数値user ID、KV namespace IDは公開設定。API keyとClient Secretはここへ書かない。
 
-### 6. Secretを登録する
+### 7. Secretを登録する
 
 ```bash
 npx wrangler secret put XAI_API_KEY
+npx wrangler secret put CLOUDFLARE_AI_GATEWAY_TOKEN
 npx wrangler secret put GITHUB_CLIENT_SECRET
 ```
 
 入力値はCloudflare Worker Secretへ保存され、リポジトリには残らない。
 
-### 7. デプロイして確認する
+### 8. デプロイして確認する
 
 ```bash
 npm run check
@@ -131,7 +146,8 @@ flowchart LR
     Worker -->|grant / token| KV[(Workers KV)]
     Worker -->|one-time auth state| Flow[OAuthFlowStore DO]
     Worker -->|reserve quota| Budget[BudgetGuard DO]
-    Worker -->|x_search| xAI[xAI Responses API]
+    Worker -->|metadata-only log| Gateway[Cloudflare AI Gateway]
+    Gateway -->|x_search| xAI[xAI Responses API]
     Worker -->|identity check| GitHub[GitHub OAuth]
 ```
 
@@ -147,9 +163,13 @@ xAIを呼ぶ前に`BudgetGuard` Durable Objectで利用枠を予約する。上�
 
 xAIリクエストは`grok-4.3`、reasoning `none`、X検索1回、出力1,200トークンに固定する。クライアントからモデル、ツール、回数、出力量は変更できない。
 
+AI Gatewayのキャッシュとレート制限は使わない。X検索の鮮度を保ちつつ、ユーザー単位の分間・日次上限は引き続き`BudgetGuard`で管理する。
+
 ### Data handling
 
-`XAI_API_KEY`と`GITHUB_CLIENT_SECRET`はWorker Secretだけに保存する。検索語、Authorization、API key、xAIのエラー本文はログへ出さず、Workers Observabilityも無効にする。
+`XAI_API_KEY`、`CLOUDFLARE_AI_GATEWAY_TOKEN`、`GITHUB_CLIENT_SECRET`はWorker Secretだけに保存する。検索語、Authorization、API key、xAIのエラー本文はWorkersログへ出さず、Workers Observabilityも無効にする。
+
+AI Gatewayではリクエスト単位に`cf-aig-collect-log-payload: false`を指定し、検索語とレスポンス本文を保存しない。モデル、トークン、コスト、ステータス、処理時間等のメタデータはGatewayのログへ保存する。[AI Gateway Logging](https://developers.cloudflare.com/ai-gateway/observability/logging/)
 
 xAIには検索語が送信され、既定ではAPIの入出力が監査目的で30日保持される。ZDRを確認できない間は、機密情報を検索語へ含めない。[xAI API Security FAQ](https://docs.x.ai/developers/faq/security)
 
@@ -197,6 +217,15 @@ xAIには検索語が送信され、既定ではAPIの入出力が監査目的�
 - 意思決定した理由
   - 購入済みの少額クレジット内で費用を予測できることと、ユーザーが明示した場合だけXを検索する狭い権限を重視した
   - メディア解析、厳密なメトリクス取得、依頼ごとの品質調整ができない欠点はあるが、モデル、ツール回数、出力量を固定し、xAIの検索と引用生成を再利用して実装と課金を抑える利点が上回ると判断した
+
+### xAIの前段にAI Gatewayを置く
+
+- その他の検討パターン
+  - xAIを直接呼ぶ: 構成とSecretが少ないが、リクエスト単位のトークン、コスト、ステータスをまとめて確認できない
+  - Cloudflareの統合APIと統合課金を使う: xAI API keyが不要になるが、既存のxAIクレジットと課金制御からCloudflare側のクレジット管理へ移行する必要がある
+- 意思決定した理由
+  - 既存のxAI API keyと`BudgetGuard`を維持したまま、失敗率、処理時間、トークン、コストをCloudflare Dashboardで確認できることを重視した
+  - 経路とGateway用Secretが増える欠点はあるが、ログ本文を保存しない設定で検索内容の保護を維持しつつ、運用状況を可視化できる利点が上回ると判断した
 
 ## Note
 

--- a/tools/xai-search-mcp/src/config.ts
+++ b/tools/xai-search-mcp/src/config.ts
@@ -2,7 +2,8 @@ export const MCP_NAME = "xai-x-search";
 export const MCP_VERSION = "0.1.0";
 
 export const XAI_MODEL = "grok-4.3";
-export const XAI_RESPONSES_URL = "https://api.x.ai/v1/responses";
+export const XAI_RESPONSES_URL =
+  "https://gateway.ai.cloudflare.com/v1/3a98b9299f91095ca897a22cc740c54b/xai-search-mcp/grok/v1/responses";
 export const XAI_REASONING_EFFORT = "none";
 export const XAI_MAX_TOOL_CALLS = 1;
 export const XAI_MAX_OUTPUT_TOKENS = 1_200;

--- a/tools/xai-search-mcp/src/env.ts
+++ b/tools/xai-search-mcp/src/env.ts
@@ -12,6 +12,7 @@ export interface AuthProps {
 export interface Env {
   ALLOWED_GITHUB_USER_ID: string;
   BUDGET_GUARD: DurableObjectNamespace<BudgetGuard>;
+  CLOUDFLARE_AI_GATEWAY_TOKEN: string;
   DCR_RATE_LIMITER: RateLimit;
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;

--- a/tools/xai-search-mcp/src/index.ts
+++ b/tools/xai-search-mcp/src/index.ts
@@ -10,7 +10,7 @@ import type { AuthProps, Env } from "./env";
 import { OAuthFlowStore } from "./oauth-flow-store";
 import { BudgetGuard, reserveSearchBudget } from "./rate-limit";
 import { xSearchInputSchema } from "./search-input";
-import { formatToolOutput, searchX } from "./xai";
+import { formatToolOutput, searchX, XaiApiError } from "./xai";
 
 export { BudgetGuard, OAuthFlowStore };
 
@@ -82,7 +82,13 @@ function createServer(workerEnv: Env): McpServer {
       }
 
       try {
-        const result = await searchX(workerEnv.XAI_API_KEY, input);
+        const result = await searchX(
+          {
+            aiGatewayToken: workerEnv.CLOUDFLARE_AI_GATEWAY_TOKEN,
+            apiKey: workerEnv.XAI_API_KEY,
+          },
+          input,
+        );
         const metadata = [
           `残り回数: 分間 ${budget.minuteRemaining} / 日次 ${budget.dailyRemaining}`,
           result.costInUsdTicks === undefined
@@ -101,8 +107,11 @@ function createServer(workerEnv: Env): McpServer {
             },
           ],
         };
-      } catch {
-        return toolError("xAIのX検索に失敗しました。予約済みの回数枠は安全側に倒して消費されます。");
+      } catch (error) {
+        const status = error instanceof XaiApiError ? `（上流HTTP ${error.status}）` : "";
+        return toolError(
+          `xAIのX検索に失敗しました${status}。予約済みの回数枠は安全側に倒して消費されます。`,
+        );
       }
     },
   );

--- a/tools/xai-search-mcp/src/xai.ts
+++ b/tools/xai-search-mcp/src/xai.ts
@@ -27,8 +27,20 @@ export interface XSearchResult {
   truncated: boolean;
 }
 
+export interface XaiCredentials {
+  aiGatewayToken: string;
+  apiKey: string;
+}
+
+export class XaiApiError extends Error {
+  constructor(readonly status: number) {
+    super(`xAI API request failed with status ${status}`);
+    this.name = "XaiApiError";
+  }
+}
+
 export async function searchX(
-  apiKey: string,
+  credentials: XaiCredentials,
   input: XSearchInput,
   fetcher: typeof fetch = fetch,
 ): Promise<XSearchResult> {
@@ -36,7 +48,9 @@ export async function searchX(
     method: "POST",
     headers: {
       Accept: "application/json",
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${credentials.apiKey}`,
+      "cf-aig-authorization": `Bearer ${credentials.aiGatewayToken}`,
+      "cf-aig-collect-log-payload": "false",
       "Content-Type": "application/json",
     },
     body: JSON.stringify(buildRequestBody(input)),
@@ -44,7 +58,7 @@ export async function searchX(
   });
 
   if (!response.ok) {
-    throw new Error(`xAI API request failed with status ${response.status}`);
+    throw new XaiApiError(response.status);
   }
 
   const body = (await response.json()) as XaiResponse;

--- a/tools/xai-search-mcp/test/xai.test.ts
+++ b/tools/xai-search-mcp/test/xai.test.ts
@@ -8,6 +8,11 @@ import {
 } from "../src/config";
 import { buildRequestBody, formatToolOutput, searchX } from "../src/xai";
 
+const credentials = {
+  aiGatewayToken: "gateway-token",
+  apiKey: "secret-key",
+};
+
 describe("buildRequestBody", () => {
   it("課金と機能の上限をクライアント入力から独立して固定する", () => {
     const body = buildRequestBody({
@@ -44,7 +49,7 @@ describe("buildRequestBody", () => {
 });
 
 describe("searchX", () => {
-  it("公式Responses APIだけをBearer認証で呼び、結果と利用量を抽出する", async () => {
+  it("認証済みAI Gateway経由でResponses APIを呼び、本文を保存せず結果と利用量を抽出する", async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
       Response.json({
         output: [
@@ -58,12 +63,16 @@ describe("searchX", () => {
       }),
     );
 
-    const result = await searchX("secret-key", { query: "test" }, fetcher);
+    const result = await searchX(credentials, { query: "test" }, fetcher);
 
     expect(fetcher).toHaveBeenCalledOnce();
     const [url, init] = fetcher.mock.calls[0];
     expect(url).toBe(XAI_RESPONSES_URL);
     expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer secret-key");
+    expect(new Headers(init?.headers).get("cf-aig-authorization")).toBe(
+      "Bearer gateway-token",
+    );
+    expect(new Headers(init?.headers).get("cf-aig-collect-log-payload")).toBe("false");
     expect(result).toEqual({
       citations: ["https://x.com/xai/status/1"],
       costInUsdTicks: 50_000_000,
@@ -84,7 +93,7 @@ describe("searchX", () => {
         }),
       );
 
-    const result = await searchX("secret-key", { query: "test" }, fetcher);
+    const result = await searchX(credentials, { query: "test" }, fetcher);
 
     expect(result.truncated).toBe(true);
     expect(result.text.startsWith("x".repeat(MAX_RESULT_CHARACTERS))).toBe(true);
@@ -96,7 +105,7 @@ describe("searchX", () => {
       .fn<typeof fetch>()
       .mockResolvedValue(new Response("secret upstream details", { status: 401 }));
 
-    await expect(searchX("secret-key", { query: "private query" }, fetcher)).rejects.toThrow(
+    await expect(searchX(credentials, { query: "private query" }, fetcher)).rejects.toThrow(
       "xAI API request failed with status 401",
     );
   });

--- a/tools/xai-search-mcp/wrangler.jsonc
+++ b/tools/xai-search-mcp/wrangler.jsonc
@@ -7,7 +7,7 @@
   "compatibility_date": "2026-08-22",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "secrets": {
-    "required": ["XAI_API_KEY", "GITHUB_CLIENT_SECRET"]
+    "required": ["XAI_API_KEY", "CLOUDFLARE_AI_GATEWAY_TOKEN", "GITHUB_CLIENT_SECRET"]
   },
   // 認証情報ではなく、デプロイを再現するための公開設定だけを置く。
   "vars": {


### PR DESCRIPTION
## 背景・概要

xAIを直接呼び出す構成では、リクエスト単位のトークン、コスト、ステータス、処理時間をまとめて確認できなかった。既存のxAI APIキーとユーザー単位の利用制限を維持したまま運用状況を可視化するため、X検索の通信経路へCloudflare AI Gatewayを追加する。

- xAI Responses APIを認証済みAI Gateway経由で呼び出す
- Gateway認証用Secretを追加し、xAI APIキーとの二重認証を行う
- リクエスト・レスポンス本文をGatewayログへ保存せず、利用量やコスト等のメタデータだけを収集する
- 検索結果の鮮度とユーザー単位の制限を維持するため、Gatewayのキャッシュとレート制限は使用せず、既存のBudgetGuardを継続利用する
- セットアップ、データ取扱い、採用理由をREADMEへ追記する

## レビューしてほしい観点

- xAI Responses APIのGatewayエンドポイントと認証ヘッダーが妥当か
- 検索語と応答本文を保存しない設定がデータ取扱い方針を満たしているか
- GatewayとBudgetGuardの責務分担が、検索の鮮度とユーザー単位の課金制御を維持できているか

## 補足

- Cloudflare側では認証済みGatewayを作成し、キャッシュとGateway単位のレート制限を無効化済み
- 最小権限のGatewayトークンをWorker Secretへ登録済み
- デプロイ後のX検索とGatewayのメタデータログ記録を確認済み
